### PR TITLE
Fix disk index out of range error

### DIFF
--- a/use/disk.go
+++ b/use/disk.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	log "github.com/Sirupsen/logrus"
 	"github.com/aasssddd/snap-plugin-lib-go/v1/plugin"
 	"github.com/pkg/errors"
 )
@@ -82,12 +83,21 @@ func listDisks() []string {
 }
 
 func readStatForDisk(diskName string, statType string, diskStatPath string) (int64, error) {
+	if diskName == "" {
+		log.Warningf("Empty diskName")
+		return 0, nil
+	}
+
 	lines, err := readLines(diskStatPath)
 	if err != nil {
 		return 0, err
 	}
+
 	for _, line := range lines {
 		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
 		if diskName == fields[2] {
 			switch statType {
 			case "timeio":
@@ -98,7 +108,7 @@ func readStatForDisk(diskName string, statType string, diskStatPath string) (int
 		}
 	}
 
-	return 0, fmt.Errorf("Can't find a disk %s.\n", diskName)
+	return 0, fmt.Errorf("Can't find a disk [%s].\n", diskName)
 }
 
 func (u *Use) diskStat(ns plugin.Namespace) (*plugin.Metric, error) {

--- a/use/use.go
+++ b/use/use.go
@@ -20,12 +20,10 @@ package use
 
 import (
 	"errors"
-	"os"
 	"path/filepath"
 	"regexp"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/aasssddd/snap-plugin-lib-go/v1/plugin"
 )
 
@@ -66,14 +64,9 @@ func NewUseCollector() *Use {
 }
 
 func (u *Use) init(cfg plugin.Config) {
-	f, err := os.OpenFile("/tmp/intel-collector-use", os.O_WRONLY|os.O_CREATE, 0666)
-	if err == nil {
-		log.SetOutput(f)
-	}
-
 	procPath, err := cfg.GetString("proc_path")
 	if err != nil {
-		procPath = "/proc_host"
+		procPath = "/proc"
 	}
 
 	u.ProcPath = procPath
@@ -157,6 +150,6 @@ func (u *Use) GetMetricTypes(cfg plugin.Config) ([]plugin.Metric, error) {
 //GetConfigPolicy returns a ConfigPolicy
 func (u *Use) GetConfigPolicy() (plugin.ConfigPolicy, error) {
 	policy := plugin.NewConfigPolicy()
-	policy.AddNewStringRule([]string{"intel", "use"}, "proc_path", false, plugin.SetDefaultString("/proc_host"))
+	policy.AddNewStringRule([]string{"intel", "use"}, "proc_path", false, plugin.SetDefaultString("/proc"))
 	return *policy, nil
 }


### PR DESCRIPTION
1)Set default proc_path to /proc
2)Remove log output to file, because the console is not easy to track log
3)Skip collect empty diskName